### PR TITLE
fix: propagate correct integration_prefix for logging

### DIFF
--- a/src/indexers/dataflow.py
+++ b/src/indexers/dataflow.py
@@ -88,7 +88,9 @@ def parse_config(
             else input_config.datadog
         )
         fetcher = fetch_logs if input_config.type == InputTypes.LOGS else fetch_metrics
-        filter_manager = FilterManager(input_config.filters)
+        filter_manager = FilterManager(
+            input_config.filters, input_config.integration_prefix
+        )
 
         filter_logic = (
             filter_manager.parse_and_filter_log

--- a/src/indexers/filters/types.py
+++ b/src/indexers/filters/types.py
@@ -100,6 +100,7 @@ class MetricEntry:
 
 @dataclass
 class FilteredEvent:
+    integration_prefix: str
     event_id: str
     event_timestamp: datetime
     customer_id: str

--- a/tests/indexers/sinks/conftest.py
+++ b/tests/indexers/sinks/conftest.py
@@ -21,6 +21,7 @@ def mocked_time():
 def test_events():
     logs = [
         {
+            "integration_prefix": "",
             "customer_id": "customer_id_one",
             "event_id": "mock_log_one",
             "event_timestamp": datetime.fromtimestamp(
@@ -29,6 +30,7 @@ def test_events():
             "values": {"example_key": "example_value_one"},
         },
         {
+            "integration_prefix": "",
             "customer_id": "customer_id_two",
             "event_id": "mock_log_two",
             "event_timestamp": datetime.fromtimestamp(
@@ -37,6 +39,7 @@ def test_events():
             "values": {"example_key": "example_value_two"},
         },
         {
+            "integration_prefix": "",
             "customer_id": "customer_id_three",
             "event_id": "mock_log_three",
             "event_timestamp": datetime.fromtimestamp(

--- a/tests/indexers/sinks/test_console_sink.py
+++ b/tests/indexers/sinks/test_console_sink.py
@@ -22,6 +22,15 @@ def test_console_sink(test_events, capsys):
     captured = capsys.readouterr()
     output = captured.out + captured.err
 
-    assert "Worker 0: FilteredEvent(event_id='mock_log_one'" in output
-    assert "Worker 0: FilteredEvent(event_id='mock_log_two'" in output
-    assert "Worker 0: FilteredEvent(event_id='mock_log_three'" in output
+    assert (
+        "Worker 0: FilteredEvent(integration_prefix='', event_id='mock_log_one'"
+        in output
+    )
+    assert (
+        "Worker 0: FilteredEvent(integration_prefix='', event_id='mock_log_two'"
+        in output
+    )
+    assert (
+        "Worker 0: FilteredEvent(integration_prefix='', event_id='mock_log_three'"
+        in output
+    )


### PR DESCRIPTION
I still wasn't able to get rid of the placeholder prefix we're passing to the sink. But we can create a ticket for Aris to look at that perhaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced filtering logic by incorporating an integration prefix, allowing for more nuanced event categorization.
	- Added a retry mechanism for batch sending, improving data transmission reliability.

- **Bug Fixes**
	- Adjusted log entry structures to include integration prefixes, standardizing output formats.

- **Tests**
	- Updated tests to reflect changes in the integration prefix handling, ensuring accurate validation of filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->