### PR TITLE
chore: update field access in secrets manager

### DIFF
--- a/src/config/secrets/manager.py
+++ b/src/config/secrets/manager.py
@@ -18,7 +18,7 @@ class SecretManager(ABC):
 
     def _resolve_secrets_in_object(self, obj):
         if isinstance(obj, BaseModel):
-            for field in obj.__fields__:
+            for field in obj.model_fields:
                 value = getattr(obj, field)
                 resolved_value = self._resolve_value(value, field)
                 setattr(obj, field, resolved_value)


### PR DESCRIPTION
Replaced the deprecated '__fields__' with 'model_fields' for accessing model fields in the _resolve_secrets_in_object method. This change ensures compatibility with the latest version of the pydantic library used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the method for resolving secrets in objects to improve field access efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->