### PR TITLE
fix: convert timestamps to UTC and fix retry behavior

### DIFF
--- a/src/indexers/filters/types.py
+++ b/src/indexers/filters/types.py
@@ -70,7 +70,15 @@ class LogEntry:
         else:
             is_json = False
 
-        event_timestamp = log_attributes.get("timestamp")
+        try:
+            # The timestamp object returned from Datadog is in timezone.localtime, but they index in UTC
+            event_timestamp = log_attributes.get("timestamp").replace(
+                tzinfo=timezone.utc
+            )
+        except AttributeError as e:
+            msg = f"Failed to parse Datadog log timestamp. Received: {log_attributes.get('timestamp')}"
+            logger.error(msg, exc_info=True)
+            raise ValueError(msg) from e
 
         return cls(
             log_id=log["id"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new enumerations (`CloudwatchInputs` and `DatadogInputs`) for API call types, enhancing clarity.
	- Added centralized `make_api_call` methods for improved API request handling and error management in both Cloudwatch and Datadog clients.
	- Enhanced timestamp parsing with error handling for Datadog logs.

- **Bug Fixes**
	- Improved error handling for API calls, specifically addressing rate limits and unexpected errors.

- **Tests**
	- Added new tests to validate retry logic and error handling for both Cloudwatch and Datadog clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->