### PR TITLE
feat: rename customer_id to organization_id across multiple files.

### DIFF
--- a/rated-config.example.yaml
+++ b/rated-config.example.yaml
@@ -19,7 +19,7 @@ inputs:
         - key: "status_code"
           field_type: "integer"
           path: "status_code"
-        - key: "customer_id"
+        - key: "organization_id"
           field_type: "string"
           path: "org.id"
         - key: "path"

--- a/src/clients/datadog.py
+++ b/src/clients/datadog.py
@@ -211,7 +211,7 @@ class DatadogClient:
         metrics_values = [
             {
                 "metric_name": metrics_config.metric_name,
-                "customer_id": metrics_config.metric_queries[i].customer_value,
+                "organization_id": metrics_config.metric_queries[i].customer_value,
                 "query_index": i,
                 "data": [
                     {"timestamp": timestamp, "value": value}
@@ -271,7 +271,7 @@ class DatadogClient:
             flattened_data = [
                 {
                     "metric_name": d["metric_name"],
-                    "customer_id": d["customer_id"],
+                    "organization_id": d["organization_id"],
                     "timestamp": item["timestamp"],
                     "value": item["value"],
                 }

--- a/src/config/models/filters.py
+++ b/src/config/models/filters.py
@@ -36,8 +36,8 @@ class FiltersYamlConfig(BaseModel):
         if not v:
             raise ValueError("Filter fields cannot be empty")
 
-        if "customer_id" not in [field.key for field in v]:
-            raise ValueError("customer_id field is required in filters")
+        if "organization_id" not in [field.key for field in v]:
+            raise ValueError("organization_id field is required in filters")
 
         if log_format == RatedParserLogFormat.RAW_TEXT:
             for field in v:

--- a/src/config/models/inputs/cloudwatch.py
+++ b/src/config/models/inputs/cloudwatch.py
@@ -31,7 +31,7 @@ class CloudwatchMetricsConfig(BaseModel):
     metric_name: StrictStr
     period: PositiveInt
     statistic: StrictStr
-    customer_identifier: StrictStr
+    organization_identifier: StrictStr
     metric_queries: List[List[CloudwatchDimension]]
 
     @model_validator(mode="before")
@@ -48,10 +48,10 @@ class CloudwatchMetricsConfig(BaseModel):
     @model_validator(mode="before")
     def validate_metric_queries(cls, values):
         metric_queries = values.get("metric_queries")
-        customer_identifier = values.get("customer_identifier")
+        organization_identifier = values.get("organization_identifier")
         if metric_queries:
             for query in metric_queries:
-                if customer_identifier not in [q["name"] for q in query]:
+                if organization_identifier not in [q["name"] for q in query]:
                     raise ValueError(
                         "Customer identifier is not found in the metric query dimensions."
                     )

--- a/src/config/models/inputs/datadog.py
+++ b/src/config/models/inputs/datadog.py
@@ -25,7 +25,7 @@ class DatadogMetricsConfig(BaseModel):
     metric_name: StrictStr
     interval: PositiveInt
     statistic: StrictStr
-    customer_identifier: StrictStr
+    organization_identifier: StrictStr
     metric_tag_data: List[DatadogTag]
     metric_queries: Optional[List[DatadogTag]] = None
 
@@ -48,9 +48,9 @@ class DatadogMetricsConfig(BaseModel):
     @model_validator(mode="before")
     def validate_metric_tag_data(cls, values):
         metric_tag_data = values.get("metric_tag_data")
-        customer_identifier = values.get("customer_identifier")
+        organization_identifier = values.get("organization_identifier")
         for tag in metric_tag_data:
-            customer_string = f"{customer_identifier}:{tag['customer_value']}"
+            customer_string = f"{organization_identifier}:{tag['customer_value']}"
             if customer_string not in tag["tag_string"]:
                 raise ValueError(
                     "Customer identifier is not found in the metric tag string."

--- a/src/indexers/filters/manager.py
+++ b/src/indexers/filters/manager.py
@@ -68,7 +68,7 @@ class FilterManager:
                 log_entry.content, version=self.filter_config.version  # type: ignore
             )
             fields = parsed_log.parsed_fields
-            if not fields or not fields.get("customer_id"):
+            if not fields or not fields.get("organization_id"):
                 return None
 
             validated_fields = {
@@ -80,8 +80,8 @@ class FilterManager:
                 integration_prefix=self.integration_prefix,
                 idempotency_key=log_entry.log_id,
                 event_timestamp=log_entry.event_timestamp,
-                customer_id=parsed_log.parsed_fields.get(
-                    "customer_id", "MISSING_CUSTOMER_ID"
+                organization_id=parsed_log.parsed_fields.get(
+                    "organization_id", "MISSING_organization_id"
                 ),
                 values=validated_fields,
             )
@@ -99,7 +99,7 @@ class FilterManager:
         try:
             idempotency_key = generate_idempotency_key(
                 event_timestamp=metrics_entry.event_timestamp,
-                customer_id=metrics_entry.customer_id,
+                organization_id=metrics_entry.organization_id,
                 values={metrics_entry.metric_name: metrics_entry.value},
             )
 
@@ -107,7 +107,7 @@ class FilterManager:
                 integration_prefix=self.integration_prefix,
                 idempotency_key=idempotency_key,
                 event_timestamp=metrics_entry.event_timestamp,
-                customer_id=metrics_entry.customer_id,
+                organization_id=metrics_entry.organization_id,
                 values={
                     self._replace_special_characters(
                         metrics_entry.metric_name

--- a/src/indexers/filters/types.py
+++ b/src/indexers/filters/types.py
@@ -11,14 +11,14 @@ logger = structlog.get_logger(__name__)
 
 
 def generate_idempotency_key(
-    event_timestamp: datetime, customer_id: str, values: dict
+    event_timestamp: datetime, organization_id: str, values: dict
 ) -> str:
     """
     Generate an idempotency key based on event timestamp, customer ID, and values.
     """
     timestamp_str = event_timestamp.isoformat()
     sorted_values = json.dumps(values, sort_keys=True)
-    components = f"{timestamp_str}|{customer_id}|{sorted_values}"
+    components = f"{timestamp_str}|{organization_id}|{sorted_values}"
     return hashlib.sha256(components.encode()).hexdigest()
 
 
@@ -97,7 +97,7 @@ class LogEntry:
 class MetricEntry:
     metric_name: str
     value: float
-    customer_id: str
+    organization_id: str
     event_timestamp: datetime
 
     @classmethod
@@ -105,7 +105,7 @@ class MetricEntry:
         return cls(
             metric_name=metric["label"],
             value=metric["value"],
-            customer_id=metric["customer_id"],
+            organization_id=metric["organization_id"],
             event_timestamp=metric[
                 "timestamp"
             ],  # TODO: Check if datetime conversion is necessary
@@ -116,7 +116,7 @@ class MetricEntry:
         return cls(
             metric_name=metric["metric_name"],
             value=metric["value"],
-            customer_id=metric["customer_id"],
+            organization_id=metric["organization_id"],
             event_timestamp=from_milliseconds(metric["timestamp"]),
         )
 
@@ -126,5 +126,5 @@ class FilteredEvent:
     integration_prefix: str
     idempotency_key: str
     event_timestamp: datetime
-    customer_id: str
+    organization_id: str
     values: dict

--- a/src/indexers/sinks/rated.py
+++ b/src/indexers/sinks/rated.py
@@ -20,7 +20,7 @@ logger = structlog.get_logger(__name__)
 
 @dataclass
 class SlaOsApiBody:
-    customer_id: str
+    organization_id: str
     timestamp: str
     key: str
     idempotency_key: str
@@ -72,7 +72,7 @@ class SlaOsApiBody:
             SlaOsApiBody: A new instance of SlaOsApiBody.
         """
         return cls(
-            customer_id=event.customer_id,
+            organization_id=event.organization_id,
             timestamp=event.event_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
             key=key,
             idempotency_key=event.idempotency_key,
@@ -129,7 +129,7 @@ class _HTTPSinkPartition(StatelessSinkPartition):
 
         for item in items:
             event_data = {
-                "customer_id": item.customer_id,
+                "organization_id": item.organization_id,
                 "timestamp": item.event_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "key": (
                     item.integration_prefix
@@ -142,12 +142,12 @@ class _HTTPSinkPartition(StatelessSinkPartition):
                 item.values, None
             )
             reserved_keys = [
-                f"{item.integration_prefix}_customer_id",
+                f"{item.integration_prefix}_organization_id",
                 f"{item.integration_prefix}_timestamp",
                 f"{item.integration_prefix}_key",
                 f"{item.integration_prefix}_idempotency_key",
                 "key",
-                "customer_id",
+                "organization_id",
                 "timestamp",
                 "idempotency_key",
             ]

--- a/templates/inputs/clients/cloudwatch/metrics_ingestion.md
+++ b/templates/inputs/clients/cloudwatch/metrics_ingestion.md
@@ -18,7 +18,7 @@ inputs:
         metric_name: Invocations
         period: 300
         statistic: Average
-        customer_identifier: FunctionName
+        organization_identifier: FunctionName
         metric_queries:
           - - name: FunctionName
               value: my-lambda-function
@@ -59,7 +59,7 @@ You need the following permissions:
 - `metric_name`: Name of the metric to ingest.
 - `period`: The granularity, in seconds, of the returned datapoints.
 - `statistic`: The statistic to use (Average, Minimum, Maximum, Sum, or SampleCount).
-- `customer_identifier`: The dimension name used to identify different customers or entities.
+- `organization_identifier`: The dimension name used to identify different customers or entities.
 - `metric_queries`: List of dimension sets to query for the metric.
 
 For more information on CloudWatch metrics, see [CloudWatch Metrics and Dimensions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html).
@@ -68,6 +68,6 @@ For more information on CloudWatch metrics, see [CloudWatch Metrics and Dimensio
 
 1. The `statistic` must be one of the predefined `CloudwatchStatistic` enum values.
 2. Each item in `metric_queries` is a list of dimensions for a specific query.
-3. The `customer_identifier` must be present in each set of dimensions in `metric_queries`.
+3. The `organization_identifier` must be present in each set of dimensions in `metric_queries`.
 4. Adjust the `period` based on your monitoring needs and CloudWatch metric resolution.
 5. Ensure your AWS credentials have permissions to read the specified CloudWatch metrics.

--- a/templates/inputs/clients/datadog/metrics_ingestion.md
+++ b/templates/inputs/clients/datadog/metrics_ingestion.md
@@ -17,7 +17,7 @@ inputs:
         metric_name: aws.lambda.invocations
         interval: 300
         statistic: avg
-        customer_identifier: function_name
+        organization_identifier: function_name
         metric_tag_data:
           - customer_value: my-lambda-function
             tag_string: "function_name:my-lambda-function,environment:prod"
@@ -41,7 +41,7 @@ You need the following scopes for the API: `events_read`.
 - `metric_name`: Name of the metric to ingest.
 - `interval`: The granularity, in seconds, of the returned datapoints.
 - `statistic`: The statistic to use (avg, min, max, or sum).
-- `customer_identifier`: The tag name used to identify different customers or entities.
+- `organization_identifier`: The tag name used to identify different customers or entities.
 - `metric_tag_data`: List of tag configurations for querying the metric.
   - `customer_value`: The value of the customer identifier tag.
   - `tag_string`: The full tag string for querying the metric.
@@ -50,6 +50,6 @@ You need the following scopes for the API: `events_read`.
 
 1. The `statistic` must be one of the predefined `DatadogStatistic` enum values.
 2. The `interval` will be automatically converted to milliseconds in the configuration.
-3. Each `tag_string` in `metric_tag_data` must include the `customer_identifier` with its corresponding `customer_value`.
+3. Each `tag_string` in `metric_tag_data` must include the `organization_identifier` with its corresponding `customer_value`.
 4. The indexer will automatically generate `metric_queries` based on the provided `metric_tag_data`.
 5. Ensure your Datadog API and application keys have permissions to read the specified metrics.

--- a/templates/inputs/clients/multi_source/cloudwatch_metrics_logs_ingestion.md
+++ b/templates/inputs/clients/multi_source/cloudwatch_metrics_logs_ingestion.md
@@ -21,7 +21,7 @@ inputs:
         metric_name: Invocations
         period: 300
         statistic: Average
-        customer_identifier: FunctionName
+        organization_identifier: FunctionName
         metric_queries:
           - - name: FunctionName
               value: my-lambda-function
@@ -41,7 +41,7 @@ inputs:
         metric_name: aws.lambda.duration
         interval: 300
         statistic: avg
-        customer_identifier: function_name
+        organization_identifier: function_name
         metric_tag_data:
           - customer_value: my-lambda-function
             tag_string: "function_name:my-lambda-function,environment:prod"

--- a/tests/clients/test_cloudwatch.py
+++ b/tests/clients/test_cloudwatch.py
@@ -31,9 +31,9 @@ class MockConfig(CloudwatchConfig):
                 metric_name="test_metric_label",
                 period=60,
                 statistic="AVERAGE",
-                customer_identifier="customer_id",
+                organization_identifier="organization_id",
                 metric_queries=[  # type: ignore
-                    [{"name": "customer_id", "value": "customer1"}],
+                    [{"name": "organization_id", "value": "customer1"}],
                 ],
             ),
         )
@@ -188,19 +188,19 @@ def test_query_metrics(mock_client):
 
     expected_metrics = [
         {
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097600000,
             "value": 1.0,
             "label": "test_metric_label",
         },
         {
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097660000,
             "value": 2.0,
             "label": "test_metric_label",
         },
         {
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097720000,
             "value": 3.0,
             "label": "test_metric_label",
@@ -217,11 +217,11 @@ def test_query_metrics(mock_client):
 def test_parse_metrics_queries():
     config = MockConfig()
     cloudwatch_client = CloudwatchClient(config)
-    customer_id_map, query_chunks = cloudwatch_client._parse_metrics_queries(
+    organization_id_map, query_chunks = cloudwatch_client._parse_metrics_queries(
         config.metrics_config
     )
 
-    expected_customer_id_map = {"test_metric_label_query_0": "customer1"}
+    expected_organization_id_map = {"test_metric_label_query_0": "customer1"}
     expected_query_chunks = [
         [
             {
@@ -230,7 +230,9 @@ def test_parse_metrics_queries():
                     "Metric": {
                         "Namespace": "test-namespace",
                         "MetricName": "test_metric_label",
-                        "Dimensions": [{"Name": "customer_id", "Value": "customer1"}],
+                        "Dimensions": [
+                            {"Name": "organization_id", "Value": "customer1"}
+                        ],
                     },
                     "Period": 60,
                     "Stat": "Average",
@@ -240,7 +242,7 @@ def test_parse_metrics_queries():
         ]
     ]
 
-    assert customer_id_map == expected_customer_id_map
+    assert organization_id_map == expected_organization_id_map
     assert query_chunks == expected_query_chunks
 
 

--- a/tests/clients/test_datadog.py
+++ b/tests/clients/test_datadog.py
@@ -30,7 +30,7 @@ class MockDatadogConfig(DatadogConfig):
                 metric_name="test.metric",
                 interval=60,
                 statistic="AVERAGE",
-                customer_identifier="customer",
+                organization_identifier="customer",
                 metric_tag_data=[  # type: ignore
                     {"customer_value": "customer1", "tag_string": "customer:customer1"},
                     {"customer_value": "customer2", "tag_string": "customer:customer2"},
@@ -188,37 +188,37 @@ def test_query_metrics(mock_metrics_api):
     expected_metrics = [
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097600000,
             "value": 1.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097660000,
             "value": 2.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097720000,
             "value": 3.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "timestamp": 1625097600000,
             "value": 4.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "timestamp": 1625097660000,
             "value": 5.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "timestamp": 1625097720000,
             "value": 6.0,
         },
@@ -261,7 +261,7 @@ def test_parse_metrics_response():
     expected_metrics = [
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "query_index": 0,
             "data": [
                 {"timestamp": 1625097600000, "value": 1.0},
@@ -270,7 +270,7 @@ def test_parse_metrics_response():
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "query_index": 1,
             "data": [{"timestamp": 1625097720000, "value": 3.0}],
         },

--- a/tests/clients/test_manager.py
+++ b/tests/clients/test_manager.py
@@ -25,7 +25,7 @@ def test_add_clients(client_manager, valid_config_dict):
             metric_name="test.metric",
             interval=60,
             statistic="AVERAGE",
-            customer_identifier="customer",
+            organization_identifier="customer",
             metric_tag_data=[
                 {"customer_value": "customer1", "tag_string": "customer:customer1"},  # type: ignore
                 {"customer_value": "customer2", "tag_string": "customer:customer2"},  # type: ignore

--- a/tests/config/test_filters_yaml_config.py
+++ b/tests/config/test_filters_yaml_config.py
@@ -24,8 +24,8 @@ class TestFiltersConfig:
                     "format": "%Y-%m-%d %H:%M:%S",
                 },
                 {
-                    "key": "customer_id",
-                    "value": "customer_id_value",
+                    "key": "organization_id",
+                    "value": "organization_id_value",
                     "field_type": "string",
                 },
             ],
@@ -65,10 +65,10 @@ class TestFiltersConfig:
                     "path": "payload.testing_key",
                 },
                 {
-                    "key": "customer_id",
-                    "value": "customer_id_value",
+                    "key": "organization_id",
+                    "value": "organization_id_value",
                     "field_type": "string",
-                    "path": "payload.customer_id",
+                    "path": "payload.organization_id",
                 },
             ],
         }

--- a/tests/config/test_secrets_manager.py
+++ b/tests/config/test_secrets_manager.py
@@ -41,7 +41,7 @@ def valid_config_with_secrets(valid_config_dict):
                 "log_example": {},
                 "fields": [
                     {
-                        "key": "customer_id",
+                        "key": "organization_id",
                         "field_type": "string",
                         "path": "path1",
                     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,10 +29,10 @@ def valid_config_dict():
                             "path": "payload.example_key",
                         },
                         {
-                            "key": "customer_id",
-                            "value": "customer_id_value",
+                            "key": "organization_id",
+                            "value": "organization_id_value",
                             "field_type": "string",
-                            "path": "payload.customer_id",
+                            "path": "payload.organization_id",
                         },
                     ],
                 },

--- a/tests/indexers/filters/test_manager.py
+++ b/tests/indexers/filters/test_manager.py
@@ -21,7 +21,7 @@ filters = FiltersYamlConfig(
         JsonFieldDefinition(key="service", field_type=FieldType.STRING, path="service"),
         JsonFieldDefinition(key="event", field_type=FieldType.STRING, path="event"),
         JsonFieldDefinition(
-            key="customer_id", field_type=FieldType.STRING, path="user_id"
+            key="organization_id", field_type=FieldType.STRING, path="user_id"
         ),
     ],
 )

--- a/tests/indexers/sinks/conftest.py
+++ b/tests/indexers/sinks/conftest.py
@@ -22,7 +22,7 @@ def test_events():
     logs = [
         {
             "integration_prefix": "",
-            "customer_id": "customer_id_one",
+            "organization_id": "organization_id_one",
             "idempotency_key": "mock_log_one",
             "event_timestamp": datetime.fromtimestamp(
                 1723041096000 / 1000, tz=timezone.utc
@@ -31,7 +31,7 @@ def test_events():
         },
         {
             "integration_prefix": "",
-            "customer_id": "customer_id_two",
+            "organization_id": "organization_id_two",
             "idempotency_key": "mock_log_two",
             "event_timestamp": datetime.fromtimestamp(
                 1723041096100 / 1000, tz=timezone.utc
@@ -40,7 +40,7 @@ def test_events():
         },
         {
             "integration_prefix": "",
-            "customer_id": "customer_id_three",
+            "organization_id": "organization_id_three",
             "idempotency_key": "mock_log_three",
             "event_timestamp": datetime.fromtimestamp(
                 1723041096200 / 1000, tz=timezone.utc

--- a/tests/indexers/sinks/test_rated_sink.py
+++ b/tests/indexers/sinks/test_rated_sink.py
@@ -35,7 +35,7 @@ def test_http_sink_3_events(
     for event_data, event in zip(body, test_events):
         assert request.method == "POST"
         assert str(request.url) == f"{endpoint}/your_ingestion_id/your_ingestion_key"
-        assert event_data["customer_id"] == event.customer_id
+        assert event_data["organization_id"] == event.organization_id
         assert event_data["timestamp"] == event.event_timestamp.strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
@@ -53,7 +53,7 @@ def test_http_sink_batch_size(
         event = test_events[i % len(test_events)]
         new_event = FilteredEvent(
             integration_prefix="",
-            customer_id=f"{event.customer_id}_{i}",
+            organization_id=f"{event.organization_id}_{i}",
             idempotency_key=f"{event.idempotency_key}_{i}",
             event_timestamp=event.event_timestamp + timedelta(seconds=i),
             values={"example_key": f"example_value_{i}"},
@@ -85,7 +85,7 @@ def test_http_sink_mixed_scenario(
         event = test_events[i % len(test_events)]
         new_event = FilteredEvent(
             integration_prefix="",
-            customer_id=f"{event.customer_id}_{i}",
+            organization_id=f"{event.organization_id}_{i}",
             idempotency_key=f"{event.idempotency_key}_{i}",
             event_timestamp=event.event_timestamp + timedelta(seconds=i),
             values={"example_key": f"example_value_{i}"},
@@ -118,7 +118,7 @@ def test_http_sink_time_based_under_timeout(
     events_batch_2 = [
         FilteredEvent(
             integration_prefix="",
-            customer_id=f"{event.customer_id}_new_{i}",
+            organization_id=f"{event.organization_id}_new_{i}",
             idempotency_key=f"{event.idempotency_key}_new_{i}",
             event_timestamp=event.event_timestamp + timedelta(seconds=8),
             values={"example_key": f"new_value_{i}"},
@@ -165,7 +165,7 @@ def test_http_sink_time_based_over_timeout(
     events_batch_2 = [
         FilteredEvent(
             integration_prefix="",
-            customer_id=f"{event.customer_id}_new_{i}",
+            organization_id=f"{event.organization_id}_new_{i}",
             idempotency_key=f"{event.idempotency_key}_new_{i}",
             event_timestamp=event.event_timestamp + timedelta(seconds=11),
             values={"example_key": f"new_value_{i}"},
@@ -216,11 +216,12 @@ def test_http_sink_time_based_over_timeout(
     for i, event in enumerate(all_events):
         if i < 3:
             assert (
-                event["customer_id"] == test_events[i].customer_id
+                event["organization_id"] == test_events[i].organization_id
             ), f"Mismatch in event {i} of first batch"
         else:
             assert (
-                event["customer_id"] == f"{test_events[i-3].customer_id}_new_{i-3}"
+                event["organization_id"]
+                == f"{test_events[i-3].organization_id}_new_{i-3}"
             ), f"Mismatch in event {i} of second batch"
 
     assert not stderr.getvalue(), f"Unexpected error output: {stderr.getvalue()}"

--- a/tests/indexers/test_dataflow.py
+++ b/tests/indexers/test_dataflow.py
@@ -55,12 +55,12 @@ def test_logs_dataflow(
         {
             "eventId": "mock_log_one",
             "timestamp": 1723041096000,
-            "message": '{"example_key": "example_value_one", "data": {"customer_id": "customer_one"}}',
+            "message": '{"example_key": "example_value_one", "data": {"organization_id": "customer_one"}}',
         },
         {
             "eventId": "mock_log_two",
             "timestamp": 1723041096100,
-            "message": '{"example_key": "example_value_two", "data": {"customer_id": "customer_two"}}',
+            "message": '{"example_key": "example_value_two", "data": {"organization_id": "customer_two"}}',
         },
     ]
     sample_log_entries = [LogEntry.from_cloudwatch_log(log) for log in sample_logs]
@@ -77,7 +77,7 @@ def test_logs_dataflow(
         log_example={
             "message": {
                 "example_key": "example_value_two",
-                "customer_id": "customer_two",
+                "organization_id": "customer_two",
             },
         },
         fields=[
@@ -87,9 +87,9 @@ def test_logs_dataflow(
                 path="example_key",
             ),
             JsonFieldDefinition(
-                key="customer_id",
+                key="organization_id",
                 field_type=FieldType.STRING,
-                path="data.customer_id",
+                path="data.organization_id",
             ),
         ],
     )
@@ -145,7 +145,7 @@ def test_metrics_dataflow(
             metric_name="test.metric",
             interval=60,
             statistic="AVERAGE",
-            customer_identifier="customer",
+            organization_identifier="customer",
             metric_tag_data=[
                 {"customer_value": "customer1", "tag_string": "customer:customer1"},  # type: ignore
                 {"customer_value": "customer2", "tag_string": "customer:customer2"},  # type: ignore
@@ -158,25 +158,25 @@ def test_metrics_dataflow(
     sample_metrics = [
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097600000,
             "value": 1.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097660000,
             "value": 2.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "timestamp": 1625097720000,
             "value": 3.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "timestamp": 1625097780000,
             "value": 4.0,
         },
@@ -280,7 +280,7 @@ def test_multiple_inputs_dataflow(
                     path="event",
                 ),
                 JsonFieldDefinition(
-                    key="customer_id",
+                    key="organization_id",
                     field_type=FieldType.STRING,
                     path="user_id",
                 ),
@@ -374,7 +374,7 @@ def test_multiple_inputs_dataflow(
     sent_data = body
 
     for item in sent_data:
-        assert "customer_id" in item, f"Missing 'customer_id' in {item}"
+        assert "organization_id" in item, f"Missing 'organization_id' in {item}"
         assert "timestamp" in item, f"Missing 'timestamp' in {item}"
         assert "key" in item, f"Missing 'key' in {item}"
         assert "values" in item, f"Missing 'values' in {item}"
@@ -409,7 +409,7 @@ def test_metrics_logs_inputs_dataflow(
                 metric_name="test.metric",
                 interval=60,
                 statistic="AVERAGE",
-                customer_identifier="customer",
+                organization_identifier="customer",
                 metric_tag_data=[
                     {"customer_value": "customer1", "tag_string": "customer:customer1"},  # type: ignore
                     {"customer_value": "customer2", "tag_string": "customer:customer2"},  # type: ignore
@@ -468,7 +468,7 @@ def test_metrics_logs_inputs_dataflow(
                     key="event", field_type=FieldType.STRING, path="event"
                 ),
                 JsonFieldDefinition(
-                    key="customer_id", field_type=FieldType.STRING, path="user_id"
+                    key="organization_id", field_type=FieldType.STRING, path="user_id"
                 ),
                 JsonFieldDefinition(
                     key="ip_address", field_type=FieldType.STRING, path="ip_address"
@@ -490,25 +490,25 @@ def test_metrics_logs_inputs_dataflow(
     sample_metrics = [
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097600000,
             "value": 1.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer1",
+            "organization_id": "customer1",
             "timestamp": 1625097660000,
             "value": 2.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "timestamp": 1625097720000,
             "value": 3.0,
         },
         {
             "metric_name": "test.metric",
-            "customer_id": "customer2",
+            "organization_id": "customer2",
             "timestamp": 1625097780000,
             "value": 4.0,
         },
@@ -599,7 +599,7 @@ def test_metrics_logs_inputs_dataflow(
 
     sent_data = body
     for item in sent_data:
-        assert "customer_id" in item, f"Missing 'customer_id' in {item}"
+        assert "organization_id" in item, f"Missing 'organization_id' in {item}"
         assert "timestamp" in item, f"Missing 'timestamp' in {item}"
         assert "key" in item, f"Missing 'key' in {item}"
         assert "values" in item, f"Missing 'values' in {item}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated terminology from "customer" to "organization" across configuration files and documentation for improved clarity.
  
- **Bug Fixes**
	- Enhanced consistency in metrics queries and validation logic by replacing all instances of `customer_id` with `organization_id`.

- **Documentation**
	- Revised metrics ingestion documents for CloudWatch and Datadog to reflect new terminology and identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->